### PR TITLE
docs(Xdebug): add

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ Enter directory in which you intend to run phpunit from. Run the desired command
 ```bash
 docker run --rm -v $(pwd):/app jitesoft/phpunit --configuration phpunit.xml
 ```
+### Debugging
+To get Xdebug to turn on its debugger you will need to set the environmental variable XDEBUG_MODE.
+
+```bash
+docker run --rm -e XDEBUG_MODE=debug -v $(pwd):/app jitesoft/phpunit --configuration phpunit.xml
+```
+Or in docker compose:
+
+```yml
+phpunit:
+    container_name: phpunit
+    image: jitesoft/phpunit:8.2
+    environment:
+      - "XDEBUG_MODE=debug"
+    volumes:
+      - "./php:/app/"
+      - "./conf/phpunit/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "./conf/phpunit/xdebug.log:/var/log/xdebug.log"
+```
 
 ### Image labels
 


### PR DESCRIPTION
Adds information about getting Xdebug to debug

**Type of change**

- [x] Documentation update

**Description**

It took me a long time (a whole afternoon) to work out that to get the xdebug debugger to break I needed to set the XDEBUG_MODE ENV. This Documentation change would have made my afternoon easier 😉 

**Related issue**

[Fixes Issue 3](https://github.com/jitesoft/docker-phpunit/issues/3)

**Motivation**

It makes uses lives easier

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [x] Documentation is updated.
